### PR TITLE
Checks to make sure output directory exists

### DIFF
--- a/scripts/run-bt-mpileup
+++ b/scripts/run-bt-mpileup
@@ -194,6 +194,7 @@ sub main
             $chrs{$chr} = 1;
             if ( $self->is_finished("$outdir/$group/$chr.bcf") ) { next; }
             if ( $self->is_finished("$outdir/$group.bcf") ) { next; }
+            if ( ! -d "$outdir/$group/$chr" ) { $self->cmd("mkdir -p '$outdir/$group/$chr'"); }
             $self->spawn('call_variants',"$outdir/$group/$chr/$chr:$from-$to.bcf",$$groups{$group},$chunk);
         }
     }


### PR DESCRIPTION
And creates it if not before spawning call_variants. 

I'm not sure where the directories are supposed to be created, but this is failing for me when chromosome names contain '*' and this fix addresses that issue.
