### PR TITLE
Quotes all paths in mkdir calls

### DIFF
--- a/modules/Runner.pm
+++ b/modules/Runner.pm
@@ -1120,7 +1120,7 @@ sub _get_temp_prefix
     my $dir  = $self->_get_temp_dir($fname);
     if ( ! -d $dir ) 
     { 
-        `mkdir -p $dir`; 
+        `mkdir -p '$dir'`;
         if ( $? ) { $self->throw("Cannot create directory [$dir]: $!"); }
     }
     return "$dir/$file";
@@ -1140,7 +1140,7 @@ sub _mkdir
 {
     my ($self,$fname) = @_;
     $fname =~ s{[^/]+$}{};
-    if ( !-e $fname ) { `mkdir -p $fname`; }
+    if ( !-e $fname ) { `mkdir -p '$fname'`; }
     return $fname;
 }
 

--- a/scripts/run-beagle
+++ b/scripts/run-beagle
@@ -266,7 +266,7 @@ sub mrProper
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     rename("$outfile.part",$outfile) or $self->throw("rename $outfile.part $outfile: $!");
 }
@@ -473,7 +473,7 @@ sub beagle
 
     if ( !-e "$prefix.vcf.gz" or $$self{redo_beagle} )
     {
-        $self->cmd(qq[mkdir -p $outdir]);
+        $self->cmd(qq[mkdir -p '$outdir']);
         my $mem = int($self->get_limits('memory') * 0.8);
         if ( $mem<=0 ) { $mem = 500; }
         my $known = defined $known_vcf ? "ref=$known_vcf" : '';
@@ -576,7 +576,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/beagle.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;

--- a/scripts/run-bt-mpileup
+++ b/scripts/run-bt-mpileup
@@ -280,7 +280,7 @@ sub clean
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     open(my $fh,'>',"$outfile.part/info.txt") or $self->throw("$outfile.part/info.txt: $!");
     print $fh $$self{_about};
@@ -294,7 +294,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/mpileup.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;
@@ -470,14 +470,14 @@ return;
     {
         if ( !exists($bam_pls{$pl}) ) { $self->throw("The platform \"$pl\" not present in any of the BAMs.\n"); }
     }
-    `mkdir -p $$self{outdir}`;
+    `mkdir -p '$$self{outdir}'`;
     $self->cmd("touch $$self{outdir}/sanity_checked");
 }
 
 sub open_file
 {
     my ($self,$file) = @_;
-    if ( ($file=~m{^(.+)/[^/]+$}) && ! -d $1 ) { $self->cmd("mkdir -p $1"); }
+    if ( ($file=~m{^(.+)/[^/]+$}) && ! -d $1 ) { $self->cmd("mkdir -p '$1'"); }
     open(my $fh,'>',$file) or $self->throw("$file: $!");
     return $fh;
 }

--- a/scripts/run-commands
+++ b/scripts/run-commands
@@ -76,7 +76,7 @@ sub main
     $self->parse_args();
 
     my @files = $self->list_files($$self{glob});
-    `mkdir -p $$self{outdir}`;
+    `mkdir -p '$$self{outdir}'`;
 
     for my $file (@files)
     {
@@ -135,7 +135,7 @@ sub run_command
 {
     my ($self,$outfile,$file) = @_;
     my $tmpdir = "$$self{outdir}/tmp.$file";
-    $self->cmd("mkdir -p $tmpdir");
+    $self->cmd("mkdir -p '$tmpdir'");
     for my $cmd (@{$$self{cmds}})
     {
         my $task = $self->expand_task(cmd=>$cmd,name=>$file,tmpdir=>$tmpdir);

--- a/scripts/run-gvcf-calling
+++ b/scripts/run-gvcf-calling
@@ -138,7 +138,7 @@ sub main
     my $outdir = $$self{outdir};
     if ( $self->is_finished("$outdir/all_done") ) { $self->all_done; }
 
-    $self->cmd(qq[mkdir -p $outdir]);
+    $self->cmd(qq[mkdir -p '$outdir']);
     $self->save_config();
 
     my $chunks = $self->init_chunks();
@@ -223,7 +223,7 @@ sub clean
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     open(my $fh,'>',"$outfile.part/info.txt") or $self->throw("$outfile.part/info.txt: $!");
     print $fh $$self{_about};
@@ -238,7 +238,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/mpileup.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;

--- a/scripts/run-impute2
+++ b/scripts/run-impute2
@@ -289,7 +289,7 @@ sub mrProper
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     rename("$outfile.part",$outfile) or $self->throw("rename $outfile.part $outfile: $!");
 }
@@ -540,7 +540,7 @@ sub vcf_to_impute2
 
     if ( $$self{phased_only} ) { $self->throw("todo: phased_only"); }
 
-    $self->cmd(qq[mkdir -p $outdir]);
+    $self->cmd(qq[mkdir -p '$outdir']);
 
     if ( exists($$self{known_vcf}) && !$self->known_hapref_exists($chr,"$from-$to") )
     {
@@ -614,7 +614,7 @@ sub impute2
                 $knowns .= " -h $known${i}.hap.gz -l $known${i}.legend.gz";
             }
             my $rg_prefix = "$$self{known_hapref}/$chr/$from-$to.ref";
-            $self->cmd(qq[mkdir -p $$self{known_hapref}/$chr/]);
+            $self->cmd(qq[mkdir -p '$$self{known_hapref}/$chr/']);
             $self->cmd(qq[$CMD $knowns -merge_ref_panels -o $rg_prefix -merge_ref_panels_output_ref $rg_prefix]);
 
             unlink("$rg_prefix.hap.samples.part");
@@ -746,7 +746,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/impute2.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;

--- a/scripts/run-runners
+++ b/scripts/run-runners
@@ -79,9 +79,9 @@ sub parse_params
     $$opts{dropbox_conf} = "$$opts{dropbox}.conf";
 
     if ( !-d $$opts{dropbox_conf} ) { error("Incorrect dropbox prefix, the directory not found: $$opts{dropbox_conf}\n\n"); }
-    if ( !-e $$opts{dropbox_in} ) { `mkdir -p $$opts{dropbox_in}`; }
-    if ( !-e $$opts{dropbox_out} ) { `mkdir -p $$opts{dropbox_out}`; }
-    if ( !-e $$opts{dropbox_tmp} ) { `mkdir -p $$opts{dropbox_tmp}`; }
+    if ( !-e $$opts{dropbox_in} ) { `mkdir -p '$$opts{dropbox_in}'`; }
+    if ( !-e $$opts{dropbox_out} ) { `mkdir -p '$$opts{dropbox_out}'`; }
+    if ( !-e $$opts{dropbox_tmp} ) { `mkdir -p '$$opts{dropbox_tmp}'`; }
     if ( !exists($$opts{err_period}) ) { $$opts{err_period} = 60; }
 
     return $opts;
@@ -272,7 +272,7 @@ sub list_projects
         $project   = parse_project($opts,$$opts{dropbox_in},$name,$run_id);
         if ( !defined $project ) { next; }
 
-        system("mkdir -p $$opts{dropbox_tmp}/$$project{run_id}");
+        system("mkdir -p '$$opts{dropbox_tmp}/$$project{run_id}'");
         system("mv $$opts{dropbox_in}/$name $$opts{dropbox_tmp}/$$project{run_id}/$name");
         if ( $? ) { confess "mv $$opts{dropbox_in}/$name $$opts{dropbox_tmp}/$$project{run_id}/$name"; }
 
@@ -296,7 +296,7 @@ sub clean_project
         if ( ref($$project{outputs}{$outdir}) eq 'ARRAY' )
         {
             # create a subdirectory '$outdir' and copy all listed files in there
-            cmd($opts,"mkdir -p $$opts{dropbox_out}/$$project{run_id}/$outdir");
+            cmd($opts,"mkdir -p '$$opts{dropbox_out}/$$project{run_id}/$outdir'");
             for my $file (@{$$project{outputs}{$outdir}})
             {
                 my $path = expand_vars($opts,$project,$file);
@@ -312,13 +312,13 @@ sub clean_project
                 $dst = $$project{outputs}{$outdir};
                 if ( $dst =~ m{([^/]+)$} ) { $dir = "$dir/$`"; $dst = "$dir/$1"; }
             }
-            cmd($opts,"mkdir -p $dir");
+            cmd($opts,"mkdir -p '$dir'");
             my $path = expand_vars($opts,$project,$outdir);
             cmd($opts,"mv $path $dst");
         }
     }
 
-    cmd($opts,"mkdir -p $$opts{dropbox_out}/$$project{run_id}/tmp-data");
+    cmd($opts,"mkdir -p '$$opts{dropbox_out}/$$project{run_id}/tmp-data'");
     cmd($opts,"mv $$opts{dropbox_tmp}/$$project{run_id} $$opts{dropbox_out}/$$project{run_id}/tmp-data");
 }
 
@@ -535,7 +535,7 @@ sub run_project
             debug_msg($opts, "step done: $prefix.$step\n");
             next; 
         }
-        if ( ! -e $prefix ) { system("mkdir -p $prefix.$step"); }
+        if ( ! -e $prefix ) { system("mkdir -p '$prefix.$step'"); }
         $$project{step} = $step;
 
         if ( exists($$project{$step}{config}) && !-e "$prefix.$step.conf" )

--- a/scripts/run-shapeit
+++ b/scripts/run-shapeit
@@ -229,7 +229,7 @@ sub mrProper
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     rename("$outfile.part",$outfile) or $self->throw("rename $outfile.part $outfile: $!");
 }
@@ -468,7 +468,7 @@ sub ref_to_shapeit
     my $outdir = $outfile;
     $outdir =~ s{/[^/]*$}{};
     my $ref_vcf = $self->expand_chrom($$self{ref_vcf},$chr);
-    $self->cmd(qq[mkdir -p $outdir]);
+    $self->cmd(qq[mkdir -p '$outdir']);
     $self->cmd(qq[$$self{bcftools} convert -r $chr:$from-$to $ref_vcf --haplegendsample $outfile.part]);
     rename("$outfile.part.samples","${prefix}_samples") or $self->throw("rename $outfile.part.samples ${prefix}_samples: $!");
     rename("$outfile.part.legend.gz","${prefix}_legend.gz") or $self->throw("rename $outfile.part.legend.gz ${prefix}_legend.gz: $!");
@@ -543,7 +543,7 @@ sub vcf_to_shapeit
     my $to   = $$chunk[2];
     my $outdir = "$$self{outdir}/$chr";
     my $in_vcf = $self->expand_chrom($$self{in_vcf},$chr);
-    $self->cmd(qq[mkdir -p $outdir]);
+    $self->cmd(qq[mkdir -p '$outdir']);
     $self->cmd(qq[$$self{bcftools} view -r $chr:$from-$to -g ^miss -Ou $in_vcf | $$self{bcftools} convert --gensample $outdir/01.vcf_to_shapeit.$from-$to]);
     if ( exists($$self{fams}) ) { $self->set_families("$outdir/01.vcf_to_shapeit.$from-$to.samples"); }
     $self->cmd(qq[touch $outfile]);
@@ -640,7 +640,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/shapeit.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;

--- a/scripts/run-st-mpileup
+++ b/scripts/run-st-mpileup
@@ -381,7 +381,7 @@ sub clean
 sub runtime_stats
 {
     my ($self,$outfile) = @_;
-    $self->cmd("mkdir -p $outfile.part");
+    $self->cmd("mkdir -p '$outfile.part'");
     $self->cmd("runtime-stats $$self{outdir} -p $outfile.part/graph > $outfile.part/stats.txt");
     open(my $fh,'>',"$outfile.part/info.txt") or $self->throw("$outfile.part/info.txt: $!");
     print $fh $$self{_about};
@@ -395,7 +395,7 @@ sub save_config
     my $src = $$self{_config};
     my $dst = "$$self{outdir}/mpileup.conf";
     if ( -e $dst && (stat($src))[9] <= (stat($dst))[9] ) { return; }
-    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p $$self{outdir}"); }
+    if ( !-d $$self{outdir} ) { $self->cmd("mkdir -p '$$self{outdir}'"); }
     open(my $fh,'>',$dst) or $self->throw("$dst: $!");
     my $about = $$self{_about};
     $about =~ s/\n/\n# /g;
@@ -430,14 +430,14 @@ sub check_sanity
     {
         if ( !exists($bam_pls{$pl}) ) { $self->throw("The platform \"$pl\" not present in any of the BAMs.\n"); }
     }
-    `mkdir -p $$self{outdir}`;
+    `mkdir -p '$$self{outdir}'`;
     $self->cmd("touch $$self{outdir}/sanity_checked");
 }
 
 sub open_file
 {
     my ($self,$file) = @_;
-    if ( ($file=~m{^(.+)/[^/]+$}) && ! -d $1 ) { $self->cmd("mkdir -p $1"); }
+    if ( ($file=~m{^(.+)/[^/]+$}) && ! -d $1 ) { $self->cmd("mkdir -p '$1'"); }
     open(my $fh,'>',$file) or $self->throw("$file: $!");
     return $fh;
 }
@@ -819,7 +819,7 @@ sub all_site_bcfs
     my $outdir = $$self{outdir};
     my $bam_list = "$outdir/lists/chr$chr-$pop.list";
 
-    `mkdir -p $outdir/$pop/$chr/` unless -d "$outdir/$pop/$chr";
+    `mkdir -p '$outdir/$pop/$chr/'` unless -d "$outdir/$pop/$chr";
     my $cmd = "$$self{mpileup} -g -r $chr:$from-$to -b $bam_list -f $$self{fa_ref} > $outfile.part";
     $self->cmd($cmd);
 
@@ -837,7 +837,7 @@ sub call_variants
 
     $self->set_chunk_options($chr,$from,$to);
 
-    `mkdir -p $outdir/$pop/$chr/` unless -d "$outdir/$pop/$chr";
+    `mkdir -p '$outdir/$pop/$chr/'` unless -d "$outdir/$pop/$chr";
 
     # Create sample list with correct ploidy info
     my $sample_list = "$outdir/$pop/$chr/$chr:$from-$to.samples";


### PR DESCRIPTION
This addresses the issue in which the shell expands unquoted
paths passed to mkdir and thereby fails to create paths when
they contain wildcard characters that happen to match another
existing path. One failure that this fixes is that output
directories are not always created when chromosome names contain
'_' characters, such as when running against the HLA_ sequences.

An example of the failure would be if an output directory:
/out/all/HLA-A_31:01:02 has been created first, and subsequently
another directory /out/all/HLA-A_01:02 is attempted to be created,
prior to this fix it would not be created because
`mkdir -p /out/all/HLA-A*01:02` is expanded by the shell to
match the existing directory (i.e. it is equivalent to
`mkdir -p /out/all/HLA-A*31:01:02`, and the desired output
directory is not created.

I went ahead and quoted _all_ instances of paths passed to mkdir
because I'm pretty sure there is never a time when you want
wildcard expansion when creating directories.
